### PR TITLE
Add style props to PayWithCard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperxyz/react-client-sdk",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "description": "Paper.xyz React Client SDK",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/components/PaperCheckout.tsx
+++ b/src/components/PaperCheckout.tsx
@@ -114,29 +114,26 @@ export const PaperCheckout: React.FC<PaperCheckoutProps> = ({
   checkoutUrl.searchParams.append('display', display);
 
   if (options.colorPrimary) {
-    checkoutUrl.searchParams.append('color_primary', options.colorPrimary);
+    checkoutUrl.searchParams.append('colorPrimary', options.colorPrimary);
   }
   if (options.colorBackground) {
-    checkoutUrl.searchParams.append(
-      'color_background',
-      options.colorBackground,
-    );
+    checkoutUrl.searchParams.append('colorBackground', options.colorBackground);
   }
   if (options.colorText) {
-    checkoutUrl.searchParams.append('color_text', options.colorText);
+    checkoutUrl.searchParams.append('colorText', options.colorText);
   }
   if (options.borderRadius !== undefined) {
     checkoutUrl.searchParams.append(
-      'border_radius',
+      'borderRadius',
       options.borderRadius.toString(),
     );
   }
   if (options.fontFamily) {
-    checkoutUrl.searchParams.append('font_family', options.fontFamily);
+    checkoutUrl.searchParams.append('fontFamily', options.fontFamily);
   }
 
   if (appName) {
-    checkoutUrl.searchParams.append('app_name', appName);
+    checkoutUrl.searchParams.append('appName', appName);
   }
   if (recipientWalletAddress) {
     checkoutUrl.searchParams.append('wallet', recipientWalletAddress);

--- a/src/components/PaperCheckout.tsx
+++ b/src/components/PaperCheckout.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { DEFAULT_BRAND_OPTIONS, PAPER_APP_URL } from '../constants/settings';
 import { PaymentSuccessResult } from '../interfaces/PaymentSuccessResult';
 import { TransferSuccessResult } from '../interfaces/TransferSuccessResult';
 
@@ -16,21 +17,21 @@ export enum PaperCheckoutDisplay {
   /**
    * Open the checkout in a modal on the parent page with a darkened background.
    *
-   * NOTE: Pay with Crypto is disabled in this view.
+   * NOTE: Pay with Crypto is disabled in this display mode.
    */
   MODAL = 'MODAL',
 
   /**
    * Open the checkout in a drawer on the right side of the parent page with a darkened background.
    *
-   * NOTE: Pay with Crypto is disabled in this view.
+   * NOTE: Pay with Crypto is disabled in this display mode.
    */
   DRAWER = 'DRAWER',
 
   /**
    * Embed the checkout directly on the parent page.
    *
-   * NOTE: Pay with Crypto is disabled in this view.
+   * NOTE: Pay with Crypto is disabled in this display mode.
    */
   EMBED = 'EMBED',
 }
@@ -38,6 +39,12 @@ export enum PaperCheckoutDisplay {
 export interface PaperCheckoutProps {
   checkoutId: string;
   display?: PaperCheckoutDisplay;
+  recipientWalletAddress?: string;
+  email?: string;
+  quantity?: number;
+  appName?: string;
+  onPaymentSuccess?: (result: PaymentSuccessResult) => void;
+  onTransferSuccess?: (result: TransferSuccessResult) => void;
   options?: {
     width: number;
     height: number;
@@ -46,27 +53,21 @@ export interface PaperCheckoutProps {
     colorText: string;
     borderRadius: number;
     fontFamily: string;
-    quantity?: number;
-    appName?: string;
-    recipientWalletAddress?: string;
-    email?: string;
   };
-  onPaymentSuccess?: (result: PaymentSuccessResult) => void;
-  onTransferSuccess?: (result: TransferSuccessResult) => void;
   children?: React.ReactNode;
 }
 
 export const PaperCheckout: React.FC<PaperCheckoutProps> = ({
   checkoutId,
   display = PaperCheckoutDisplay.POPUP,
+  recipientWalletAddress,
+  email,
+  quantity,
+  appName,
   options = {
     width: 400,
     height: 800,
-    colorPrimary: '#cf3781',
-    colorBackground: '#ffffff',
-    colorText: '#1a202c',
-    borderRadius: 12,
-    fontFamily: 'Open Sans',
+    ...DEFAULT_BRAND_OPTIONS,
   },
   onPaymentSuccess,
   onTransferSuccess,
@@ -74,6 +75,7 @@ export const PaperCheckout: React.FC<PaperCheckoutProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
+  // Handle message events from iframe.
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       const data = event.data;
@@ -107,7 +109,8 @@ export const PaperCheckout: React.FC<PaperCheckoutProps> = ({
     window.addEventListener('message', handleMessage);
   }, []);
 
-  const checkoutUrl = new URL(`https://paper.xyz/checkout/${checkoutId}`);
+  // Build iframe URL with query params.
+  const checkoutUrl = new URL(`/checkout/${checkoutId}`, PAPER_APP_URL);
   checkoutUrl.searchParams.append('display', display);
 
   if (options.colorPrimary) {
@@ -122,7 +125,7 @@ export const PaperCheckout: React.FC<PaperCheckoutProps> = ({
   if (options.colorText) {
     checkoutUrl.searchParams.append('color_text', options.colorText);
   }
-  if (options.borderRadius) {
+  if (options.borderRadius !== undefined) {
     checkoutUrl.searchParams.append(
       'border_radius',
       options.borderRadius.toString(),
@@ -132,17 +135,17 @@ export const PaperCheckout: React.FC<PaperCheckoutProps> = ({
     checkoutUrl.searchParams.append('font_family', options.fontFamily);
   }
 
-  if (options.appName) {
-    checkoutUrl.searchParams.append('app_name', options.appName);
+  if (appName) {
+    checkoutUrl.searchParams.append('app_name', appName);
   }
-  if (options.recipientWalletAddress) {
-    checkoutUrl.searchParams.append('wallet', options.recipientWalletAddress);
+  if (recipientWalletAddress) {
+    checkoutUrl.searchParams.append('wallet', recipientWalletAddress);
   }
-  if (options.email) {
-    checkoutUrl.searchParams.append('username', options.email);
+  if (email) {
+    checkoutUrl.searchParams.append('username', email);
   }
-  if (options.quantity) {
-    checkoutUrl.searchParams.append('quantity', options.quantity.toString());
+  if (quantity) {
+    checkoutUrl.searchParams.append('quantity', quantity.toString());
   }
 
   const clickableElement = children || (

--- a/src/components/PayWithCard.tsx
+++ b/src/components/PayWithCard.tsx
@@ -98,25 +98,25 @@ export const PayWithCard: React.FC<PayWithCardProps> = ({
     payWithCardUrl.searchParams.append('quantity', quantity.toString());
   }
   if (options.colorPrimary) {
-    payWithCardUrl.searchParams.append('color_primary', options.colorPrimary);
+    payWithCardUrl.searchParams.append('colorPrimary', options.colorPrimary);
   }
   if (options.colorBackground) {
     payWithCardUrl.searchParams.append(
-      'color_background',
+      'colorBackground',
       options.colorBackground,
     );
   }
   if (options.colorText) {
-    payWithCardUrl.searchParams.append('color_text', options.colorText);
+    payWithCardUrl.searchParams.append('colorText', options.colorText);
   }
   if (options.borderRadius !== undefined) {
     payWithCardUrl.searchParams.append(
-      'border_radius',
+      'borderRadius',
       options.borderRadius.toString(),
     );
   }
   if (options.fontFamily) {
-    payWithCardUrl.searchParams.append('font_family', options.fontFamily);
+    payWithCardUrl.searchParams.append('fontFamily', options.fontFamily);
   }
 
   return (

--- a/src/components/PayWithCard.tsx
+++ b/src/components/PayWithCard.tsx
@@ -1,13 +1,24 @@
 import React, { useEffect } from 'react';
-import { PAPER_APP_URL } from '../constants/settings';
+import { DEFAULT_BRAND_OPTIONS, PAPER_APP_URL } from '../constants/settings';
 import { PaperSDKError, PaperSDKErrorCode } from '../interfaces/PaperSDKError';
 import { PaymentSuccessResult } from '../interfaces/PaymentSuccessResult';
+import { TransferSuccessResult } from '../interfaces/TransferSuccessResult';
 import { usePaperSDKContext } from '../Provider';
 
 interface PayWithCardProps {
   checkoutId: string;
   recipientWalletAddress: string;
-  onSuccess: (result: PaymentSuccessResult) => void;
+  email?: string;
+  quantity?: number;
+  options?: {
+    colorPrimary?: string;
+    colorBackground?: string;
+    colorText?: string;
+    borderRadius?: number;
+    fontFamily?: string;
+  };
+  onPaymentSuccess?: (result: PaymentSuccessResult) => void;
+  onTransferSuccess?: (result: TransferSuccessResult) => void;
   onCancel?: () => void;
   onError?: (error: PaperSDKError) => void;
 }
@@ -15,46 +26,105 @@ interface PayWithCardProps {
 export const PayWithCard: React.FC<PayWithCardProps> = ({
   checkoutId,
   recipientWalletAddress,
-  onSuccess,
+  email,
+  quantity,
+  options = {
+    ...DEFAULT_BRAND_OPTIONS,
+  },
+  onPaymentSuccess,
+  onTransferSuccess,
   onCancel,
   onError,
 }) => {
   const { chainName } = usePaperSDKContext();
 
+  // Handle message events from iframe.
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      // if (event.origin !== "https://paper.xyz") return;
-
       const data = event.data;
-      console.log('data is ', data);
 
-      if (data.eventType === 'payWithCardError') {
-        console.error('Error in Paper SDK PayWithCard', data.error);
-        if (onError) {
-          onError({ code: data.errorCode as PaperSDKErrorCode });
-        }
-      } else if (data.eventType === 'payWithCardCancel') {
-        console.error('Paper SDK PayWithCard cancelled');
-        if (onCancel) {
-          onCancel();
-        }
-      } else if (data.eventType === 'payWithCardSuccess') {
-        onSuccess({ id: data.id });
+      switch (data.eventType) {
+        case 'payWithCardError':
+          console.error('Error in Paper SDK PayWithCard', data.error);
+          if (onError) {
+            onError({ code: data.errorCode as PaperSDKErrorCode });
+          }
+          break;
+
+        case 'payWithCardCancel':
+          console.error('Paper SDK PayWithCard cancelled');
+          if (onCancel) {
+            onCancel();
+          }
+          break;
+
+        case 'payWithCardPaymentSuccess':
+          if (onPaymentSuccess) {
+            onPaymentSuccess({ id: data.id });
+          }
+          break;
+
+        case 'payWithCardTransferSuccess':
+          if (onTransferSuccess) {
+            // @ts-ignore
+            onTransferSuccess({
+              id: data.id,
+              // ...
+            });
+          }
+          break;
+
+        default:
+        // Ignore unrecognized event
       }
     };
 
     window.addEventListener('message', handleMessage);
   }, []);
 
+  // Build iframe URL with query params.
+  const payWithCardUrl = new URL('/sdk/v1/pay-with-card', PAPER_APP_URL);
+
+  payWithCardUrl.searchParams.append('checkoutId', checkoutId);
+  payWithCardUrl.searchParams.append(
+    'recipientWalletAddress',
+    recipientWalletAddress,
+  );
+  payWithCardUrl.searchParams.append('chainName', chainName);
+  if (email) {
+    payWithCardUrl.searchParams.append('email', email);
+  }
+  if (quantity) {
+    payWithCardUrl.searchParams.append('quantity', quantity.toString());
+  }
+  if (options.colorPrimary) {
+    payWithCardUrl.searchParams.append('color_primary', options.colorPrimary);
+  }
+  if (options.colorBackground) {
+    payWithCardUrl.searchParams.append(
+      'color_background',
+      options.colorBackground,
+    );
+  }
+  if (options.colorText) {
+    payWithCardUrl.searchParams.append('color_text', options.colorText);
+  }
+  if (options.borderRadius !== undefined) {
+    payWithCardUrl.searchParams.append(
+      'border_radius',
+      options.borderRadius.toString(),
+    );
+  }
+  if (options.fontFamily) {
+    payWithCardUrl.searchParams.append('font_family', options.fontFamily);
+  }
+
   return (
-    <>
-      {checkoutId && recipientWalletAddress && chainName && (
-        <iframe
-          src={`${PAPER_APP_URL}/sdk/v1/pay-with-card?checkoutId=${checkoutId}&recipientWalletAddress=${recipientWalletAddress}&chainName=${chainName}`}
-          width='100%'
-          height='100%'
-        ></iframe>
-      )}
-    </>
+    <iframe
+      src={payWithCardUrl.href}
+      width='100%'
+      height='100%'
+      allowTransparency
+    />
   );
 };

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -1,1 +1,9 @@
 export const PAPER_APP_URL = 'https://paper.xyz';
+
+export const DEFAULT_BRAND_OPTIONS = {
+  colorPrimary: '#cf3781',
+  colorBackground: '#ffffff',
+  colorText: '#1a202c',
+  borderRadius: 12,
+  fontFamily: 'Open Sans',
+};


### PR DESCRIPTION
- Add styling prop support for the `PayWithCard` component.
- Move non-styling params out of the `options` object and into root params.