### PR TITLE
Automatically close popup when onPaymentSuccess if provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperxyz/react-client-sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Paper.xyz React Client SDK",
   "source": "src/index.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
Closes the review payment popup after successful payment when onPaymentSuccess is provided. This enables the calling page to fully own the post-payment buyer experience.