### PR TITLE
Add app-defined metadata as a prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperxyz/react-client-sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Paper.xyz React Client SDK",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/components/PaperCheckout.tsx
+++ b/src/components/PaperCheckout.tsx
@@ -42,6 +42,7 @@ export interface PaperCheckoutProps {
   recipientWalletAddress?: string;
   emailAddress?: string;
   quantity?: number;
+  metadata?: Record<string, any>;
   appName?: string;
   onPaymentSuccess?: (result: PaymentSuccessResult) => void;
   onTransferSuccess?: (result: TransferSuccessResult) => void;
@@ -63,6 +64,7 @@ export const PaperCheckout: React.FC<PaperCheckoutProps> = ({
   recipientWalletAddress,
   emailAddress,
   quantity,
+  metadata,
   appName,
   options = {
     width: 400,
@@ -146,6 +148,12 @@ export const PaperCheckout: React.FC<PaperCheckoutProps> = ({
   }
   if (quantity) {
     checkoutUrl.searchParams.append('quantity', quantity.toString());
+  }
+  if (metadata) {
+    checkoutUrl.searchParams.append(
+      'metadata',
+      encodeURIComponent(JSON.stringify(metadata)),
+    );
   }
 
   checkoutUrl.searchParams.append('date', Date.now().toString());

--- a/src/components/PayWithCard.tsx
+++ b/src/components/PayWithCard.tsx
@@ -48,6 +48,7 @@ interface PayWithCardProps {
   recipientWalletAddress: string;
   emailAddress: string;
   quantity?: number;
+  metadata?: Record<string, any>;
   options?: {
     colorPrimary?: string;
     colorBackground?: string;
@@ -66,6 +67,7 @@ export const PayWithCard: React.FC<PayWithCardProps> = ({
   recipientWalletAddress,
   emailAddress,
   quantity,
+  metadata,
   options = {
     ...DEFAULT_BRAND_OPTIONS,
   },
@@ -183,6 +185,12 @@ export const PayWithCard: React.FC<PayWithCardProps> = ({
   }
   if (quantity) {
     payWithCardUrl.searchParams.append('quantity', quantity.toString());
+  }
+  if (metadata) {
+    payWithCardUrl.searchParams.append(
+      'metadata',
+      encodeURIComponent(JSON.stringify(metadata)),
+    );
   }
   if (options.colorPrimary) {
     payWithCardUrl.searchParams.append('colorPrimary', options.colorPrimary);


### PR DESCRIPTION
Accept a `metadata` prop to allow the app to provide per-transaction metadata. This metadata is provided as a `metadata` field for payment and transfer webhook events.

The metadata must be an object of string keys to any serializable value. Essentially the data should be readable when `JSON.stringify(metadata)` is called.

**Example**
Pass in prop:
```typescript
metadata={{
  "name": "watermelon",
  "type": "fruit",
}}
```

The webhook will contain:
```json
"metadata": {
  "name": "watermelon",
  "type": "fruit"
}
```