### PR TITLE
Add class names on modal elements to allow customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperxyz/react-client-sdk",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Paper.xyz React Client SDK",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -35,7 +35,7 @@ export const Modal = ({
     <Transition appear show={isOpen} as={Fragment}>
       <Dialog
         as='div'
-        className='relative z-10'
+        className='paper-modal relative z-[1000]'
         onClose={clickOutsideModalToClose ? onClose : () => {}}
       >
         {/* Overlay */}
@@ -48,7 +48,7 @@ export const Modal = ({
           leaveFrom='opacity-100'
           leaveTo='opacity-0'
         >
-          <div className='fixed inset-0 bg-black bg-opacity-50' />
+          <div className='paper-modal-overlay fixed inset-0 bg-black bg-opacity-50' />
         </Transition.Child>
 
         <div className='fixed inset-0 overflow-y-auto'>
@@ -63,7 +63,7 @@ export const Modal = ({
               leaveTo='opacity-0 scale-95'
             >
               <Dialog.Panel
-                className='relative max-h-full max-w-full transform overflow-x-auto overflow-y-hidden rounded-lg p-5 text-left align-middle shadow-xl transition-all sm:m-4'
+                className='paper-modal-content relative max-h-full max-w-full transform overflow-x-auto overflow-y-hidden rounded-lg p-5 text-left align-middle shadow-xl transition-all sm:m-4'
                 style={{ backgroundColor: bgColor }}
               >
                 <CloseButton onClose={onClose} />

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -634,6 +634,10 @@ video {
   z-index: 10;
 }
 
+.z-\[1000\] {
+  z-index: 1000;
+}
+
 .m-3 {
   margin: 0.75rem;
 }
@@ -1264,15 +1268,5 @@ video {
 @media (min-width: 640px) {
   .sm\:m-4 {
     margin: 1rem;
-  }
-
-  .sm\:rounded-lg {
-    border-radius: 0.5rem;
-  }
-
-  .sm\:shadow-xl {
-    --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-    --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
-    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   }
 }


### PR DESCRIPTION
Add new class names on the PayWithCard modal to allow customization via css.
- `paper-modal`
  - `paper-modal-overlay`
  - `paper-modal-content`