### PR TITLE
Add cardholderName to PayWithCard.onReview prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperxyz/react-client-sdk",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Paper.xyz React Client SDK",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/components/PayWithCard.tsx
+++ b/src/components/PayWithCard.tsx
@@ -101,7 +101,10 @@ export const PayWithCard: React.FC<PayWithCardProps> = ({
 
         case 'review':
           if (onReview) {
-            onReview({ id: data.id });
+            onReview({
+              id: data.id,
+              cardholderName: data.cardholderName,
+            });
           }
           break;
 

--- a/src/interfaces/ReviewResult.ts
+++ b/src/interfaces/ReviewResult.ts
@@ -3,4 +3,9 @@ export interface ReviewResult {
    * A unique ID for this purchase.
    */
   id: string;
+
+  /**
+   * The cardholder's full name provided by the buyer.
+   */
+  cardholderName: string;
 }


### PR DESCRIPTION
Add the cardholder's name to onReview so the app can refer to the buyer's name, e.g. the page shows a toast "Thanks for your purchase, {first name}!"

⚠️ Please use this sparingly and consider splitting on whitespace to grab the buyer's first name only. It can be an intimidating experience for a buyer to see their full name rendered in most places.